### PR TITLE
Show_error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "publisher": "HuggingFace",
   "name": "huggingface-vscode",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "displayName": "HF Code Autocomplete",
   "description": "AI Autocomplete for OSS code-gen models",
   "icon": "small_logo.png",

--- a/src/runCompletion.ts
+++ b/src/runCompletion.ts
@@ -13,6 +13,7 @@ import { getTabnineExtensionContext } from "./globals/tabnineExtensionContext";
 export type CompletionType = "normal" | "snippet";
 
 let didShowTokenWarning = false;
+const errorShownDate: Record<number, number> = {};
 
 export default async function runCompletion(
   document: TextDocument,
@@ -87,6 +88,12 @@ export default async function runCompletion(
 
   if(!res.ok){
     console.error("Error sending a request", res.status, res.statusText);
+    const FIVE_MIN_MS = 300_000;
+    const showError = !errorShownDate[res.status] || Date.now() - errorShownDate[res.status] > FIVE_MIN_MS;
+    if(showError){
+      errorShownDate[res.status] = Date.now();
+      await window.showErrorMessage(`HF Code Error: code - ${res.status}; msg - ${res.statusText}`);
+    }
     setDefaultStatus();
     return null;
   }


### PR DESCRIPTION
TLDR:
1. When request to server fails, show the error using [vscode.window.showErrorMessage](https://code.visualstudio.com/api/references/vscode-api) box. (Previously, error was just being output o the log system)
2. Show a same error only once within 5 minutes